### PR TITLE
Exposing a port in options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ var options = new MongoRunnerOptions
     ConnectionTimeout = TimeSpan.FromSeconds(10), // Default: 30 seconds
     ReplicaSetSetupTimeout = TimeSpan.FromSeconds(5), // Default: 10 seconds
     AdditionalArguments = "--quiet", // Default: null
+    MongoPort = 27017, // Default: random port selection
 };
 
 // Disposing the runner will kill the MongoDB process (mongod) and delete the associated data directory

--- a/src/EphemeralMongo.Core/MongoRunner.cs
+++ b/src/EphemeralMongo.Core/MongoRunner.cs
@@ -58,7 +58,7 @@ public sealed class MongoRunner
                 // Ignored - this data directory might already be in use, we'll see later how mongod reacts
             }
 
-            this._options.MongoPort = this._portFactory.GetRandomAvailablePort();
+            this._options.MongoPort ??= this._portFactory.GetRandomAvailablePort();
 
             // Build MongoDB executable arguments
             var arguments = string.Format(CultureInfo.InvariantCulture, "--dbpath {0} --port {1} --bind_ip 127.0.0.1", ProcessArgument.Escape(this._dataDirectory), this._options.MongoPort);

--- a/src/EphemeralMongo.Core/MongoRunnerOptions.cs
+++ b/src/EphemeralMongo.Core/MongoRunnerOptions.cs
@@ -66,7 +66,7 @@ public sealed class MongoRunnerOptions
     // Internal properties start here
     internal string ReplicaSetName { get; set; } = "singleNodeReplSet";
 
-    internal int MongoPort { get; set; }
+    public int? MongoPort { get; set; }
 
     private static Exception? CheckDirectoryPathFormat(string? path)
     {

--- a/src/EphemeralMongo.Core/MongoRunnerOptions.cs
+++ b/src/EphemeralMongo.Core/MongoRunnerOptions.cs
@@ -63,10 +63,10 @@ public sealed class MongoRunnerOptions
 
     public Logger? StandardErrorLogger { get; set; }
 
+    public int? MongoPort { get; set; }
+
     // Internal properties start here
     internal string ReplicaSetName { get; set; } = "singleNodeReplSet";
-
-    public int? MongoPort { get; set; }
 
     private static Exception? CheckDirectoryPathFormat(string? path)
     {

--- a/src/EphemeralMongo.Core/PublicAPI.Shipped.txt
+++ b/src/EphemeralMongo.Core/PublicAPI.Shipped.txt
@@ -24,4 +24,6 @@ EphemeralMongo.MongoRunnerOptions.StandardOuputLogger.get -> EphemeralMongo.Logg
 EphemeralMongo.MongoRunnerOptions.StandardOuputLogger.set -> void
 EphemeralMongo.MongoRunnerOptions.UseSingleNodeReplicaSet.get -> bool
 EphemeralMongo.MongoRunnerOptions.UseSingleNodeReplicaSet.set -> void
+EphemeralMongo.MongoRunnerOptions.MongoPort.get -> int?
+EphemeralMongo.MongoRunnerOptions.MongoPort.set -> void
 static EphemeralMongo.MongoRunner.Run(EphemeralMongo.MongoRunnerOptions? options = null) -> EphemeralMongo.IMongoRunner!


### PR DESCRIPTION
Hi! 

Thanks for your project, very useful setting. Motivation:
- the deterministic assigned port looks a little bit more predictable in our case
- for our integration tests enough single MongoDB instance 