### PR TITLE
Ubuntu 24.04 support for MongoDB 6 and 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - if: matrix.os == 'ubuntu-24.04'
         run: |
-          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - if: matrix.os == 'ubuntu-24.04'
         run: |
-          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - if: matrix.os == 'ubuntu-22.04'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, ubuntu-22.04, windows-2022, macos-14]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,19 +22,23 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
 
-      # MongoDB Enterprise prerequisites for Ubuntu 22.04
+      # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
+      - if: matrix.os == 'ubuntu-24.04'
+        run: |
+          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - if: matrix.os == 'ubuntu-22.04'
         run: |
           sudo apt-get install libcurl4 libgssapi-krb5-2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 
-      - if: matrix.os == 'ubuntu-22.04'
+      - if: matrix.os == 'ubuntu-24.04'
         run: ./build.ps1
         shell: pwsh
         env:
           NUGET_SOURCE: ${{ secrets.MYGET_SOURCE }}
           NUGET_API_KEY: ${{ secrets.MYGET_API_KEY }}
 
-      - if: matrix.os != 'ubuntu-22.04'
+      - if: matrix.os != 'ubuntu-24.04'
         run: ./build.ps1
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -14,10 +14,9 @@ jobs:
 
       - uses: actions/setup-dotnet@v4
 
-      # MongoDB Enterprise prerequisites for Ubuntu 22.04
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - run: |
-          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 
       - run: ./build.ps1
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - run: |
-          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 
       - run: ./build.ps1
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
       # https://www.mongodb.com/docs/manual/tutorial/install-mongodb-enterprise-on-ubuntu-tarball/#prerequisites
       - run: |
-          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
+          sudo apt-get install libcurl4 libgssapi-krb5-2 libldap2 libldap-2.5-0 libwrap0 libsasl2-2 libsasl2-modules libsasl2-modules-gssapi-mit snmp openssl liblzma5
 
       - run: ./build.ps1
         shell: pwsh

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   renovate:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   semgrep:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository
     permissions:

--- a/src/EphemeralMongo.Tests/DownloadTargetHelperTests.cs
+++ b/src/EphemeralMongo.Tests/DownloadTargetHelperTests.cs
@@ -18,14 +18,14 @@ public sealed class DownloadTargetHelperTests : IDisposable
     [Fact]
     public void GetTarget_ReturnsWindows_WhenOsPlatformIsWindows()
     {
-        var target = this._helper.GetTarget(OSPlatform.Windows);
+        var target = this._helper.GetTarget(OSPlatform.Windows, MongoVersion.V8);
         Assert.Equal("windows", target);
     }
 
     [Fact]
     public void GetTarget_ReturnsMacOS_WhenOsPlatformIsOSX()
     {
-        var target = this._helper.GetTarget(OSPlatform.OSX);
+        var target = this._helper.GetTarget(OSPlatform.OSX, MongoVersion.V8);
         Assert.Equal("macos", target);
     }
 
@@ -72,7 +72,18 @@ public sealed class DownloadTargetHelperTests : IDisposable
     public void GetTarget_ReturnsLinuxTarget_WhenLinuxOsReleaseFileExists(string actualId, string actualVersionId, string expectedTarget)
     {
         this.CreateOsReleaseFile(actualId, actualVersionId);
-        var target = this._helper.GetTarget(OSPlatform.Linux);
+        var target = this._helper.GetTarget(OSPlatform.Linux, MongoVersion.V8);
+        Assert.Equal(expectedTarget, target);
+    }
+
+    [Theory]
+    [InlineData("ubuntu", "24.04", "ubuntu2204", MongoVersion.V6)]
+    [InlineData("ubuntu", "24.04", "ubuntu2204", MongoVersion.V7)]
+    [InlineData("ubuntu", "24.04", "ubuntu2404", MongoVersion.V8)]
+    public void GetTarget_AdjustsLinuxTarget_ForOlderMongoVersions(string actualId, string actualVersionId, string expectedTarget, MongoVersion version)
+    {
+        this.CreateOsReleaseFile(actualId, actualVersionId);
+        var target = this._helper.GetTarget(OSPlatform.Linux, version);
         Assert.Equal(expectedTarget, target);
     }
 
@@ -89,14 +100,14 @@ public sealed class DownloadTargetHelperTests : IDisposable
     public void GetTarget_ThrowsNotSupportedException_WhenOsVersionIsInvalid(string id, string versionId)
     {
         this.CreateOsReleaseFile(id, versionId);
-        var exception = Assert.Throws<NotSupportedException>(() => this._helper.GetTarget(OSPlatform.Linux));
+        var exception = Assert.Throws<NotSupportedException>(() => this._helper.GetTarget(OSPlatform.Linux, MongoVersion.V8));
         Assert.Contains(versionId, exception.Message);
     }
 
     [Fact]
     public void GetTarget_ReturnsFallbackTarget_WhenOsReleaseFileDoesNotExist()
     {
-        var target = this._helper.GetTarget(OSPlatform.Linux);
+        var target = this._helper.GetTarget(OSPlatform.Linux, MongoVersion.V8);
         Assert.Equal("ubuntu2204", target);
     }
 
@@ -109,7 +120,7 @@ public sealed class DownloadTargetHelperTests : IDisposable
     public void GetTarget_ReturnsFallbackTarget_WhenVersionIdIsMissing(string id)
     {
         this.CreateOsReleaseFile(id, versionId: null);
-        var target = this._helper.GetTarget(OSPlatform.Linux);
+        var target = this._helper.GetTarget(OSPlatform.Linux, MongoVersion.V8);
         Assert.Equal("ubuntu2204", target);
     }
 
@@ -125,7 +136,7 @@ public sealed class DownloadTargetHelperTests : IDisposable
     public void GetTarget_ReturnsFallbackTarget_WhenIdIsMissing(string versionId)
     {
         this.CreateOsReleaseFile(id: null, versionId);
-        var target = this._helper.GetTarget(OSPlatform.Linux);
+        var target = this._helper.GetTarget(OSPlatform.Linux, MongoVersion.V8);
         Assert.Equal("ubuntu2204", target);
     }
 
@@ -133,7 +144,7 @@ public sealed class DownloadTargetHelperTests : IDisposable
     public void GetTarget_ReturnsFallbackTarget_WhenBothIdAndVersionIdAreMissing()
     {
         this.CreateOsReleaseFile(id: null, versionId: null);
-        var target = this._helper.GetTarget(OSPlatform.Linux);
+        var target = this._helper.GetTarget(OSPlatform.Linux, MongoVersion.V8);
         Assert.Equal("ubuntu2204", target);
     }
 
@@ -146,7 +157,7 @@ public sealed class DownloadTargetHelperTests : IDisposable
     public void GetTarget_ReturnsFallbackTarget_WhenIdIsNotSupported(string id, string versionId)
     {
         this.CreateOsReleaseFile(id, versionId);
-        var target = this._helper.GetTarget(OSPlatform.Linux);
+        var target = this._helper.GetTarget(OSPlatform.Linux, MongoVersion.V8);
         Assert.Equal("ubuntu2204", target);
     }
 
@@ -155,7 +166,7 @@ public sealed class DownloadTargetHelperTests : IDisposable
     public void GetTarget_ThrowsPlatformNotSupportedException_WhenOsPlatformIsUnsupported()
     {
         var unsupportedPlatform = OSPlatform.FreeBSD;
-        Assert.Throws<PlatformNotSupportedException>(() => this._helper.GetTarget(unsupportedPlatform));
+        Assert.Throws<PlatformNotSupportedException>(() => this._helper.GetTarget(unsupportedPlatform, MongoVersion.V8));
     }
 #endif
 
@@ -194,3 +205,4 @@ public sealed class DownloadTargetHelperTests : IDisposable
         }
     }
 }
+

--- a/src/EphemeralMongo.Tests/MongoRunnerTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerTests.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using EphemeralMongo.Download;
 using MongoDB.Driver;
 
 namespace EphemeralMongo.Tests;
@@ -108,6 +110,15 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
     [InlineData(true, MongoVersion.V8, MongoEdition.Enterprise)]
     public async Task Import_Export_Works(bool replset, MongoVersion version, MongoEdition edition)
     {
+        if (version is MongoVersion.V6 or MongoVersion.V7 && edition == MongoEdition.Enterprise && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            var target = DownloadTargetHelper.Instance.GetOriginalLinuxTarget();
+            if (target == "ubuntu2404")
+            {
+                Assert.Skip("Enterprise MongoDB 6 and 7 are not supported on Ubuntu 24.04");
+            }
+        }
+
         const string databaseName = "default";
         const string collectionName = "people";
 

--- a/src/EphemeralMongo/Download/DownloadTargetHelper.cs
+++ b/src/EphemeralMongo/Download/DownloadTargetHelper.cs
@@ -5,7 +5,7 @@ namespace EphemeralMongo.Download;
 
 internal sealed class DownloadTargetHelper(string linuxOsReleasePath)
 {
-    private static readonly DownloadTargetHelper Instance = new DownloadTargetHelper("/etc/os-release");
+    internal static readonly DownloadTargetHelper Instance = new DownloadTargetHelper("/etc/os-release");
 
     public static string GetTarget(MongoVersion version)
     {
@@ -38,7 +38,7 @@ internal sealed class DownloadTargetHelper(string linuxOsReleasePath)
         // For instance, there's no specific MongoDB binaries targeting Ubuntu 24.04 for MongoDB 7 and earlier,
         // but it works if use the Ubuntu 22.04 binaries on Ubuntu 24.04.
         // We're focusing on Ubuntu for now as it's the most common Linux distribution for CIs.
-        var originalTarget = this.GetLinuxTarget();
+        var originalTarget = this.GetOriginalLinuxTarget();
 
         if (originalTarget == "ubuntu2404" && version is MongoVersion.V6 or MongoVersion.V7)
         {
@@ -53,7 +53,7 @@ internal sealed class DownloadTargetHelper(string linuxOsReleasePath)
         "^(?<key>ID|VERSION_ID)=\"?(?<value>[^\"]+)\"?$",
         RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
-    private string GetLinuxTarget()
+    internal string GetOriginalLinuxTarget()
     {
         string? target = null;
         try

--- a/src/EphemeralMongo/Download/DownloadTargetHelper.cs
+++ b/src/EphemeralMongo/Download/DownloadTargetHelper.cs
@@ -7,12 +7,12 @@ internal sealed class DownloadTargetHelper(string linuxOsReleasePath)
 {
     private static readonly DownloadTargetHelper Instance = new DownloadTargetHelper("/etc/os-release");
 
-    public static string GetTarget()
+    public static string GetTarget(MongoVersion version)
     {
-        return Instance.GetTarget(RuntimeInformationHelper.OSPlatform);
+        return Instance.GetTarget(RuntimeInformationHelper.OSPlatform, version);
     }
 
-    public string GetTarget(OSPlatform platform)
+    public string GetTarget(OSPlatform platform, MongoVersion version)
     {
         if (platform == OSPlatform.Windows)
         {
@@ -26,10 +26,26 @@ internal sealed class DownloadTargetHelper(string linuxOsReleasePath)
 
         if (platform == OSPlatform.Linux)
         {
-            return this.GetLinuxTarget();
+            return this.GetAdjustedLinuxTarget(version);
         }
 
         throw new PlatformNotSupportedException($"Unsupported operating system {RuntimeInformation.OSDescription}");
+    }
+
+    private string GetAdjustedLinuxTarget(MongoVersion version)
+    {
+        // Some Linux distributions have limited support for older MongoDB versions.
+        // For instance, there's no specific MongoDB binaries targeting Ubuntu 24.04 for MongoDB 7 and earlier,
+        // but it works if use the Ubuntu 22.04 binaries on Ubuntu 24.04.
+        // We're focusing on Ubuntu for now as it's the most common Linux distribution for CIs.
+        var originalTarget = this.GetLinuxTarget();
+
+        if (originalTarget == "ubuntu2404" && version is MongoVersion.V6 or MongoVersion.V7)
+        {
+            return "ubuntu2204";
+        }
+
+        return originalTarget;
     }
 
     // Matches ID and VERSION_ID keys and their values without quotes in /etc/os-release

--- a/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
+++ b/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
@@ -28,7 +28,7 @@ internal static class MongoExecutableDownloader
         var majorVersion = (int)options.Version;
         var edition = DownloadEditionHelper.GetEdition(options.Edition);
         var architecture = DownloadArchitectureHelper.GetArchitecture();
-        var target = DownloadTargetHelper.GetTarget();
+        var target = DownloadTargetHelper.GetTarget(options.Version);
 
         var baseExeDirName = string.Format(CultureInfo.InvariantCulture, "{0}-{1}-{2}", MongodExeFileNameWithoutExt, edition, majorVersion);
         var baseExeDirPath = Path.Combine(AppDataDirPath, "bin", MongodExeFileNameWithoutExt, baseExeDirName);
@@ -168,7 +168,7 @@ internal static class MongoExecutableDownloader
             }
 
             var architecture = DownloadArchitectureHelper.GetArchitecture();
-            var target = DownloadTargetHelper.GetTarget();
+            var target = DownloadTargetHelper.GetTarget(options.Version);
 
             var mongoToolsVersions = await options.Transport.GetFromJsonAsync<ToolsVersionsDto>("https://downloads.mongodb.org/tools/db/release.json", cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
This pull request includes significant updates to the CI/CD workflows and enhancements to the `DownloadTargetHelper` class to support different MongoDB versions. The most important changes include adding support for Ubuntu 24.04 in the CI/CD workflows and modifying the `DownloadTargetHelper` class to adjust targets based on MongoDB versions.

### CI/CD Workflow Updates:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R42): Added support for Ubuntu 24.04 in the matrix and updated MongoDB prerequisites and build steps accordingly.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L9-R19): Updated the `runs-on` configuration to use Ubuntu 24.04.
* [`.github/workflows/renovate.yml`](diffhunk://#diff-2f2dcee4f3f279ea8d2f4cd0235f2ab917d8cf1d8e11f4f195a3816afe79af26L10-R10): Updated the `runs-on` configuration to use Ubuntu 24.04.
* [`.github/workflows/semgrep.yml`](diffhunk://#diff-943c91ac8e5085136f071a01d6ad70ffe7beefb141dd4d45c3fc75c52c3c9dbbL12-R12): Updated the `runs-on` configuration to use Ubuntu 24.04.

### Codebase Enhancements:

* [`src/EphemeralMongo/Download/DownloadTargetHelper.cs`](diffhunk://#diff-42268c40230fda98a28fc5e342ec030da3c0bc7c36fa0f24f54ddc4afc89bb34L10-R15): Modified the `GetTarget` method to accept a `MongoVersion` parameter and added logic to adjust Linux targets for older MongoDB versions.
* [`src/EphemeralMongo/Download/MongoExecutableDownloader.cs`](diffhunk://#diff-684fdcb90a4555bc8b1cdaa32dc5842592b74db9260c31465470dbcb56d18f55L31-R31): Updated the `DownloadMongodAsync` method to pass the `MongoVersion` parameter to the `GetTarget` method. [[1]](diffhunk://#diff-684fdcb90a4555bc8b1cdaa32dc5842592b74db9260c31465470dbcb56d18f55L31-R31) [[2]](diffhunk://#diff-684fdcb90a4555bc8b1cdaa32dc5842592b74db9260c31465470dbcb56d18f55L171-R171)

### Test Updates:

* [`src/EphemeralMongo.Tests/DownloadTargetHelperTests.cs`](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL21-R28): Updated test methods to include the `MongoVersion` parameter and added new test cases to verify target adjustments for older MongoDB versions. [[1]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL21-R28) [[2]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL75-R86) [[3]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL92-R110) [[4]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL112-R123) [[5]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL128-R147) [[6]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL149-R160) [[7]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fL158-R169) [[8]](diffhunk://#diff-5803b8b1d3378884c85b508fd9ad86158fc1f9270596770feb2bf19601e2b42fR208)