### PR TITLE
Added pooled mongo runner and cancellation token support for synchronous methods

### DIFF
--- a/src/EphemeralMongo.Tests/MongoRunnerTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerTests.cs
@@ -173,7 +173,7 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
 
 #pragma warning disable CA1849 // We want to test synchronous methods
             IMongoRunner runner2;
-            using (runner2 = MongoRunner.Run(options))
+            using (runner2 = MongoRunner.Run(options, testContextAccessor.Current.CancellationToken))
             {
                 var database = new MongoClient(runner2.ConnectionString).GetDatabase(databaseName);
 
@@ -182,7 +182,7 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
                 Assert.Null(personBeforeImport);
 
                 // Import the exported collection
-                runner2.Import(databaseName, collectionName, exportedFilePath, ["--jsonArray"]);
+                runner2.Import(databaseName, collectionName, exportedFilePath, ["--jsonArray"], drop: false, testContextAccessor.Current.CancellationToken);
 
                 // Verify that the document was imported successfully
                 var personAfterImport = database.GetCollection<Person>(collectionName).Find(FilterDefinition<Person>.Empty).FirstOrDefault(testContextAccessor.Current.CancellationToken);

--- a/src/EphemeralMongo.Tests/PooledMongoRunnerTests.cs
+++ b/src/EphemeralMongo.Tests/PooledMongoRunnerTests.cs
@@ -1,0 +1,312 @@
+﻿using MongoDB.Bson;
+using MongoDB.Driver;
+
+#pragma warning disable EMEX0001 // Type is for evaluation purposes only
+
+namespace EphemeralMongo.Tests;
+
+public class PooledMongoRunnerTests(ITestContextAccessor testContextAccessor)
+{
+    [Fact]
+    public async Task RentAsync_Returns_New_Runner_When_Pool_Is_Empty()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+
+        // Act
+        using var pool = new PooledMongoRunner(options);
+        using var runner = await pool.RentAsync(testContextAccessor.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(runner);
+        Assert.NotNull(runner.ConnectionString);
+        Assert.Contains("mongodb://127.0.0.1", runner.ConnectionString);
+
+        // Verify server is running
+        await this.PingServerAsync(runner.ConnectionString);
+    }
+
+    [Fact]
+    public void Rent_Returns_New_Runner_When_Pool_Is_Empty()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+
+        // Act
+        using var pool = new PooledMongoRunner(options);
+        using var runner = pool.Rent(testContextAccessor.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(runner);
+        Assert.NotNull(runner.ConnectionString);
+        Assert.Contains("mongodb://127.0.0.1", runner.ConnectionString);
+
+        // Verify server is running
+        this.PingServer(runner.ConnectionString);
+    }
+
+    [Fact]
+    public async Task RentAsync_Reuses_Runner_When_Returned_And_Not_MaxedOut()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        using var pool = new PooledMongoRunner(options, 2);
+
+        // Act
+        var runner1 = await pool.RentAsync(testContextAccessor.Current.CancellationToken);
+        var connectionString1 = runner1.ConnectionString;
+        pool.Return(runner1);
+
+        var runner2 = await pool.RentAsync(testContextAccessor.Current.CancellationToken);
+        var connectionString2 = runner2.ConnectionString;
+
+        // Assert
+        Assert.Equal(connectionString1, connectionString2);
+        Assert.Same(runner1, runner2);
+
+        // Verify server is still running
+        await this.PingServerAsync(runner2.ConnectionString);
+
+        // Cleanup
+        pool.Return(runner2);
+    }
+
+    [Fact]
+    public void Rent_Reuses_Runner_When_Returned_And_Not_MaxedOut()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        using var pool = new PooledMongoRunner(options, 2);
+
+        // Act
+        var runner1 = pool.Rent(testContextAccessor.Current.CancellationToken);
+        var connectionString1 = runner1.ConnectionString;
+        pool.Return(runner1);
+
+        var runner2 = pool.Rent(testContextAccessor.Current.CancellationToken);
+        var connectionString2 = runner2.ConnectionString;
+
+        // Assert
+        Assert.Equal(connectionString1, connectionString2);
+        Assert.Same(runner1, runner2);
+
+        // Verify server is still running
+        this.PingServer(runner2.ConnectionString);
+
+        // Cleanup
+        pool.Return(runner2);
+    }
+
+    [Fact]
+    public async Task RentAsync_Creates_New_Runner_When_MaxRentals_Reached()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        using var pool = new PooledMongoRunner(options, 1);
+
+        // Act
+        var runner1 = await pool.RentAsync(testContextAccessor.Current.CancellationToken);
+        var connectionString1 = runner1.ConnectionString;
+        pool.Return(runner1);
+
+        var runner2 = await pool.RentAsync(testContextAccessor.Current.CancellationToken);
+        var connectionString2 = runner2.ConnectionString;
+
+        // Assert
+        Assert.NotEqual(connectionString1, connectionString2);
+        Assert.NotSame(runner1, runner2);
+
+        // Verify server is running for the new runner
+        await this.PingServerAsync(runner2.ConnectionString);
+
+        // Cleanup
+        pool.Return(runner2);
+    }
+
+    [Fact]
+    public void Rent_Creates_New_Runner_When_MaxRentals_Reached()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        using var pool = new PooledMongoRunner(options, 1);
+
+        // Act
+        var runner1 = pool.Rent(testContextAccessor.Current.CancellationToken);
+        var connectionString1 = runner1.ConnectionString;
+        pool.Return(runner1);
+
+        var runner2 = pool.Rent(testContextAccessor.Current.CancellationToken);
+        var connectionString2 = runner2.ConnectionString;
+
+        // Assert
+        Assert.NotEqual(connectionString1, connectionString2);
+        Assert.NotSame(runner1, runner2);
+
+        // Verify server is running for the new runner
+        this.PingServer(runner2.ConnectionString);
+
+        // Cleanup
+        pool.Return(runner2);
+    }
+
+    [Fact]
+    public void Return_Throws_When_Runner_Not_From_Pool()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        using var pool = new PooledMongoRunner(options);
+        using var externalRunner = MongoRunner.Run(options, testContextAccessor.Current.CancellationToken);
+
+        // Act & Assert
+        Assert.Throws<InvalidOperationException>(() => pool.Return(externalRunner));
+    }
+
+    [Fact]
+    public async Task Return_Disposes_Runner_When_MaxRentals_Reached()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        using var pool = new PooledMongoRunner(options, 1);
+
+        // Act
+        var runner = await pool.RentAsync(testContextAccessor.Current.CancellationToken);
+        var connectionString = runner.ConnectionString;
+
+        // Verify the server is running before returning
+        await this.PingServerAsync(connectionString);
+
+        // Return the runner - it will be marked for disposal because it reached max rentals (1)
+        pool.Return(runner);
+
+        // Rent again - should get a new runner since we've maxed rentals at 1
+        var runner2 = await pool.RentAsync(testContextAccessor.Current.CancellationToken);
+
+        // At this point, the original runner should be disposed
+        // Trying to use it should throw a connection exception
+        await Assert.ThrowsAnyAsync<TimeoutException>(() => this.PingServerAsync(connectionString));
+
+        // But the new runner should be working
+        await this.PingServerAsync(runner2.ConnectionString);
+
+        // Cleanup
+        pool.Return(runner2);
+    }
+
+    [Fact]
+    public void Dispose_Disposes_All_Runners()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        var pool = new PooledMongoRunner(options);
+
+        // Act
+        var runner1 = pool.Rent(testContextAccessor.Current.CancellationToken);
+        var runner2 = pool.Rent(testContextAccessor.Current.CancellationToken);
+        var connectionString1 = runner1.ConnectionString;
+        var connectionString2 = runner2.ConnectionString;
+
+        // Assert clients connect successfully before disposal
+        this.PingServer(connectionString1);
+        this.PingServer(connectionString2);
+
+        // Dispose the pool without returning the runners
+        pool.Dispose();
+
+        // Assert clients cannot connect anymore
+        Assert.ThrowsAny<TimeoutException>(() => this.PingServer(connectionString1));
+        Assert.ThrowsAny<TimeoutException>(() => this.PingServer(connectionString2));
+    }
+
+    [Fact]
+    public async Task Rent_Throws_ObjectDisposedException_When_Disposed()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        var pool = new PooledMongoRunner(options);
+        pool.Dispose();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            pool.RentAsync(testContextAccessor.Current.CancellationToken));
+        Assert.Throws<ObjectDisposedException>(() => pool.Rent(testContextAccessor.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Return_Throws_ObjectDisposedException_When_Disposed()
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+        var pool = new PooledMongoRunner(options);
+        var runner = pool.Rent(testContextAccessor.Current.CancellationToken);
+        pool.Dispose();
+
+        // Act & Assert
+        Assert.Throws<ObjectDisposedException>(() => pool.Return(runner));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_Throws_When_MaxRentalsPerRunner_LessThan_One(int maxRentals)
+    {
+        // Arrange
+        var options = CreateDefaultOptions();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new PooledMongoRunner(options, maxRentals));
+    }
+
+    [Fact]
+    public void Constructor_Throws_When_Options_Is_Null()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new PooledMongoRunner(null!));
+    }
+
+    [Fact]
+    public void Pool_Creates_MaxRentalsPerRunner_Distinct_Instances()
+    {
+        // Arrange
+        const int maxRentalsPerRunner = 10;
+        const int totalRentals = 100;
+        const int expectedDistinctInstances = 10;
+
+        var options = CreateDefaultOptions();
+        using var pool = new PooledMongoRunner(options, maxRentalsPerRunner);
+        var connectionStrings = new HashSet<string>(StringComparer.Ordinal);
+
+        // Act
+        for (var i = 0; i < totalRentals; i++)
+        {
+            var runner = pool.Rent(testContextAccessor.Current.CancellationToken);
+            connectionStrings.Add(runner.ConnectionString);
+        }
+
+        // Assert
+        Assert.Equal(expectedDistinctInstances, connectionStrings.Count);
+    }
+
+    private void PingServer(string connectionString)
+    {
+        GetAdminDatabase(connectionString).RunCommand<BsonDocument>(new BsonDocument("ping", 1), cancellationToken: testContextAccessor.Current.CancellationToken);
+    }
+
+    private async Task PingServerAsync(string connectionString)
+    {
+        await GetAdminDatabase(connectionString).RunCommandAsync<BsonDocument>(new BsonDocument("ping", 1), cancellationToken: testContextAccessor.Current.CancellationToken);
+    }
+
+    private static MongoRunnerOptions CreateDefaultOptions() => new();
+
+    private static IMongoDatabase GetAdminDatabase(string connectionString)
+    {
+        var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
+
+        clientSettings.ConnectTimeout = TimeSpan.FromSeconds(1);
+        clientSettings.HeartbeatTimeout = TimeSpan.FromSeconds(1);
+        clientSettings.SocketTimeout = TimeSpan.FromSeconds(1);
+        clientSettings.ServerSelectionTimeout = TimeSpan.FromSeconds(1);
+
+        return new MongoClient(clientSettings).GetDatabase("admin");
+    }
+}

--- a/src/EphemeralMongo/ExperimentalAttribute.cs
+++ b/src/EphemeralMongo/ExperimentalAttribute.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+// This was adapted from https://github.com/dotnet/runtime/blob/v9.0.4/src/libraries/System.Private.CoreLib/src/System/Diagnostics/CodeAnalysis/ExperimentalAttribute.cs
+
+#pragma warning disable
+
+#if !NET8_0_OR_GREATER
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Assembly |
+                    AttributeTargets.Module |
+                    AttributeTargets.Class |
+                    AttributeTargets.Struct |
+                    AttributeTargets.Enum |
+                    AttributeTargets.Constructor |
+                    AttributeTargets.Method |
+                    AttributeTargets.Property |
+                    AttributeTargets.Field |
+                    AttributeTargets.Event |
+                    AttributeTargets.Interface |
+                    AttributeTargets.Delegate, Inherited = false)]
+    internal sealed class ExperimentalAttribute : Attribute
+    {
+        public ExperimentalAttribute(string diagnosticId)
+        {
+            // ReSharper disable once ArrangeThisQualifier
+            DiagnosticId = diagnosticId;
+        }
+
+        public string DiagnosticId { get; }
+
+        public string? UrlFormat { get; set; }
+    }
+}
+
+#endif // !NET8_0_OR_LATER

--- a/src/EphemeralMongo/IMongoRunner.cs
+++ b/src/EphemeralMongo/IMongoRunner.cs
@@ -6,9 +6,9 @@ public interface IMongoRunner : IDisposable
 
     Task ImportAsync(string database, string collection, string inputFilePath, string[]? additionalArguments = null, bool drop = false, CancellationToken cancellationToken = default);
 
-    void Import(string database, string collection, string inputFilePath, string[]? additionalArguments = null, bool drop = false);
+    void Import(string database, string collection, string inputFilePath, string[]? additionalArguments = null, bool drop = false, CancellationToken cancellationToken = default);
 
     Task ExportAsync(string database, string collection, string outputFilePath, string[]? additionalArguments = null, CancellationToken cancellationToken = default);
 
-    void Export(string database, string collection, string outputFilePath, string[]? additionalArguments = null);
+    void Export(string database, string collection, string outputFilePath, string[]? additionalArguments = null, CancellationToken cancellationToken = default);
 }

--- a/src/EphemeralMongo/MongoRunner.cs
+++ b/src/EphemeralMongo/MongoRunner.cs
@@ -37,9 +37,9 @@ public sealed class MongoRunner
         return runner.RunInternalAsync(cancellationToken);
     }
 
-    public static IMongoRunner Run(MongoRunnerOptions? options = null)
+    public static IMongoRunner Run(MongoRunnerOptions? options = null, CancellationToken cancellationToken = default)
     {
-        return RunAsync(options).ConfigureAwait(false).GetAwaiter().GetResult();
+        return RunAsync(options, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
     }
 
     private async Task<IMongoRunner> RunInternalAsync(CancellationToken cancellationToken)
@@ -228,7 +228,7 @@ public sealed class MongoRunner
 
         public string ConnectionString { get; }
 
-        [SuppressMessage("Maintainability", "CA1513", Justification = "ObjectDisposedException.ThrowIf isn't worth it")]
+        [SuppressMessage("Maintainability", "CA1513", Justification = "ObjectDisposedException.ThrowIf isn't worth it when multi-targeting")]
         public async Task ImportAsync(string database, string collection, string inputFilePath, string[]? additionalArguments = null, bool drop = false, CancellationToken cancellationToken = default)
         {
             if (Interlocked.CompareExchange(ref this._isDisposed, 0, 0) == 1)
@@ -284,13 +284,12 @@ public sealed class MongoRunner
             }
         }
 
-        public void Import(string database, string collection, string inputFilePath, string[]? additionalArguments = null, bool drop = false)
+        public void Import(string database, string collection, string inputFilePath, string[]? additionalArguments = null, bool drop = false, CancellationToken cancellationToken = default)
         {
-            this.ImportAsync(database, collection, inputFilePath, additionalArguments, drop).ConfigureAwait(false).GetAwaiter().GetResult();
+            this.ImportAsync(database, collection, inputFilePath, additionalArguments, drop, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
-        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1117:Parameters should be on same line or separate lines", Justification = "Would have used too many lines, and this way string.Format is still very readable")]
-        [SuppressMessage("Maintainability", "CA1513", Justification = "ObjectDisposedException.ThrowIf isn't worth it")]
+        [SuppressMessage("Maintainability", "CA1513", Justification = "ObjectDisposedException.ThrowIf isn't worth it when multi-targeting")]
         public async Task ExportAsync(string database, string collection, string outputFilePath, string[]? additionalArguments = null, CancellationToken cancellationToken = default)
         {
             if (Interlocked.CompareExchange(ref this._isDisposed, 0, 0) == 1)
@@ -341,9 +340,9 @@ public sealed class MongoRunner
             }
         }
 
-        public void Export(string database, string collection, string outputFilePath, string[]? additionalArguments = null)
+        public void Export(string database, string collection, string outputFilePath, string[]? additionalArguments = null, CancellationToken cancellationToken = default)
         {
-            this.ExportAsync(database, collection, outputFilePath, additionalArguments).ConfigureAwait(false).GetAwaiter().GetResult();
+            this.ExportAsync(database, collection, outputFilePath, additionalArguments, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         public void Dispose()

--- a/src/EphemeralMongo/PooledMongoRunner.cs
+++ b/src/EphemeralMongo/PooledMongoRunner.cs
@@ -1,0 +1,188 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace EphemeralMongo;
+
+[Experimental("EMEX0001")]
+[SuppressMessage("Maintainability", "CA1513", Justification = "ObjectDisposedException.ThrowIf isn't worth it when multi-targeting")]
+public sealed class PooledMongoRunner : IDisposable
+{
+    private readonly MongoRunnerOptions _options;
+    private readonly int _maxRentalsPerRunner;
+    private readonly SemaphoreSlim _mutex = new SemaphoreSlim(1, 1);
+    private readonly List<RunnerInfo> _runners = [];
+    private bool _isDisposed;
+
+    public PooledMongoRunner(MongoRunnerOptions options, int maxRentalsPerRunner = 100)
+    {
+        this._options = options ?? throw new ArgumentNullException(nameof(options));
+        this._maxRentalsPerRunner = maxRentalsPerRunner < 1
+            ? throw new ArgumentOutOfRangeException(nameof(maxRentalsPerRunner), "Maximum rentals per runner must be greater than 0")
+            : maxRentalsPerRunner;
+    }
+
+    public async Task<IMongoRunner> RentAsync(CancellationToken cancellationToken = default)
+    {
+        await this._mutex.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            if (this._isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(PooledMongoRunner));
+            }
+
+            if (this._runners.FirstOrDefault(r => r.TotalRentals < this._maxRentalsPerRunner) is { } availableRunner)
+            {
+                availableRunner.ReferenceCount++;
+                availableRunner.TotalRentals++;
+
+                return availableRunner.Runner;
+            }
+
+            var newRunner = await MongoRunner.RunAsync(this._options, cancellationToken).ConfigureAwait(false);
+            var newRunnerInfo = new RunnerInfo(newRunner);
+            this._runners.Add(newRunnerInfo);
+
+            return newRunner;
+        }
+        finally
+        {
+            this._mutex.Release();
+        }
+    }
+
+    public IMongoRunner Rent(CancellationToken cancellationToken = default)
+    {
+        this._mutex.Wait(cancellationToken);
+
+        try
+        {
+            if (this._isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(PooledMongoRunner));
+            }
+
+            if (this._runners.FirstOrDefault(r => r.TotalRentals < this._maxRentalsPerRunner) is { } availableRunner)
+            {
+                availableRunner.ReferenceCount++;
+                availableRunner.TotalRentals++;
+
+                return availableRunner.Runner;
+            }
+
+            var newRunner = MongoRunner.Run(this._options, cancellationToken);
+            var newRunnerInfo = new RunnerInfo(newRunner);
+            this._runners.Add(newRunnerInfo);
+
+            return newRunner;
+        }
+        finally
+        {
+            this._mutex.Release();
+        }
+    }
+
+    public void Return(IMongoRunner runner)
+    {
+        if (runner == null)
+        {
+            throw new ArgumentNullException(nameof(runner));
+        }
+
+        RunnerInfo? runnerToDispose = null;
+
+        this._mutex.Wait();
+
+        try
+        {
+            if (this._isDisposed)
+            {
+                throw new ObjectDisposedException(nameof(PooledMongoRunner));
+            }
+
+            var runnerInfo = this._runners.FirstOrDefault(r => runner == r.Runner);
+            if (runnerInfo == null)
+            {
+                throw new InvalidOperationException("The returned runner was not rented from this pool");
+            }
+
+            runnerInfo.ReferenceCount--;
+
+            if (runnerInfo.ReferenceCount <= 0 && runnerInfo.TotalRentals >= this._maxRentalsPerRunner)
+            {
+                runnerToDispose = runnerInfo;
+                this._runners.Remove(runnerInfo);
+            }
+        }
+        finally
+        {
+            this._mutex.Release();
+        }
+
+        runnerToDispose?.Runner.Dispose();
+    }
+
+    public void Dispose()
+    {
+        if (this._isDisposed)
+        {
+            return;
+        }
+
+        List<RunnerInfo>? runnersToDispose;
+
+        this._mutex.Wait();
+
+        try
+        {
+            if (this._isDisposed)
+            {
+                return;
+            }
+
+            this._isDisposed = true;
+
+            runnersToDispose = [.. this._runners];
+            this._runners.Clear();
+        }
+        finally
+        {
+            this._mutex.Release();
+        }
+
+        if (runnersToDispose.Count > 0)
+        {
+            foreach (var runner in runnersToDispose)
+            {
+                try
+                {
+                    runner.Runner.Dispose();
+                }
+                catch
+                {
+                    // ignore
+                }
+            }
+
+            try
+            {
+                this._mutex.Dispose();
+            }
+            catch
+            {
+                // ignore
+            }
+        }
+        else
+        {
+            this._mutex.Dispose();
+        }
+    }
+
+    private class RunnerInfo(IMongoRunner runner)
+    {
+        public IMongoRunner Runner { get; } = runner;
+        public int ReferenceCount { get; set; } = 1;
+        public int TotalRentals { get; set; } = 1;
+    }
+}

--- a/src/EphemeralMongo/PublicAPI.Shipped.txt
+++ b/src/EphemeralMongo/PublicAPI.Shipped.txt
@@ -4,9 +4,9 @@ EphemeralMongo.HttpTransport.HttpTransport(System.Net.Http.HttpClient! httpClien
 EphemeralMongo.HttpTransport.HttpTransport(System.Net.Http.HttpMessageHandler! handler) -> void
 EphemeralMongo.IMongoRunner
 EphemeralMongo.IMongoRunner.ConnectionString.get -> string!
-EphemeralMongo.IMongoRunner.Export(string! database, string! collection, string! outputFilePath, string![]? additionalArguments = null) -> void
+EphemeralMongo.IMongoRunner.Export(string! database, string! collection, string! outputFilePath, string![]? additionalArguments = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 EphemeralMongo.IMongoRunner.ExportAsync(string! database, string! collection, string! outputFilePath, string![]? additionalArguments = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
-EphemeralMongo.IMongoRunner.Import(string! database, string! collection, string! inputFilePath, string![]? additionalArguments = null, bool drop = false) -> void
+EphemeralMongo.IMongoRunner.Import(string! database, string! collection, string! inputFilePath, string![]? additionalArguments = null, bool drop = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> void
 EphemeralMongo.IMongoRunner.ImportAsync(string! database, string! collection, string! inputFilePath, string![]? additionalArguments = null, bool drop = false, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
 EphemeralMongo.Logger
 EphemeralMongo.MongoEdition
@@ -47,5 +47,5 @@ EphemeralMongo.MongoVersion
 EphemeralMongo.MongoVersion.V6 = 6 -> EphemeralMongo.MongoVersion
 EphemeralMongo.MongoVersion.V7 = 7 -> EphemeralMongo.MongoVersion
 EphemeralMongo.MongoVersion.V8 = 8 -> EphemeralMongo.MongoVersion
-static EphemeralMongo.MongoRunner.Run(EphemeralMongo.MongoRunnerOptions? options = null) -> EphemeralMongo.IMongoRunner!
+static EphemeralMongo.MongoRunner.Run(EphemeralMongo.MongoRunnerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> EphemeralMongo.IMongoRunner!
 static EphemeralMongo.MongoRunner.RunAsync(EphemeralMongo.MongoRunnerOptions? options = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<EphemeralMongo.IMongoRunner!>!

--- a/src/EphemeralMongo/PublicAPI.Unshipped.txt
+++ b/src/EphemeralMongo/PublicAPI.Unshipped.txt
@@ -1,1 +1,7 @@
 #nullable enable
+EphemeralMongo.PooledMongoRunner
+EphemeralMongo.PooledMongoRunner.Dispose() -> void
+EphemeralMongo.PooledMongoRunner.PooledMongoRunner(EphemeralMongo.MongoRunnerOptions! options, int maxRentalsPerRunner = 100) -> void
+EphemeralMongo.PooledMongoRunner.Rent(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> EphemeralMongo.IMongoRunner!
+EphemeralMongo.PooledMongoRunner.RentAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<EphemeralMongo.IMongoRunner!>!
+EphemeralMongo.PooledMongoRunner.Return(EphemeralMongo.IMongoRunner! runner) -> void


### PR DESCRIPTION
This pull request introduces several significant changes to the `EphemeralMongo` project, mainly focusing on adding support for cancellation tokens, implementing a new `PooledMongoRunner` class, and adding an `ExperimentalAttribute` for conditional compilation. The most important changes are summarized below:

### Support for Cancellation Tokens:
* [`src/EphemeralMongo/IMongoRunner.cs`](diffhunk://#diff-01c982b6138c71d6c9d72af890fa7ce72e2aa5d505b8134684c9cfd53ce8c95aL9-R13): Added `CancellationToken` parameters to `Import` and `Export` methods in the `IMongoRunner` interface.
* [`src/EphemeralMongo/MongoRunner.cs`](diffhunk://#diff-0ab9ba3ecdfa8726fc8bb2be164f908f15bb47445f48a56fa3d94be51ac0275eL40-R42): Updated the `Run`, `Import`, and `Export` methods to accept `CancellationToken` parameters. [[1]](diffhunk://#diff-0ab9ba3ecdfa8726fc8bb2be164f908f15bb47445f48a56fa3d94be51ac0275eL40-R42) [[2]](diffhunk://#diff-0ab9ba3ecdfa8726fc8bb2be164f908f15bb47445f48a56fa3d94be51ac0275eL287-R292) [[3]](diffhunk://#diff-0ab9ba3ecdfa8726fc8bb2be164f908f15bb47445f48a56fa3d94be51ac0275eL344-R345)
* [`src/EphemeralMongo.Tests/MongoRunnerTests.cs`](diffhunk://#diff-946b14507f16234d8b1314943d601b403a66305004afbf320ef33cf46d51861cL176-R176): Modified test methods to pass `CancellationToken` to `MongoRunner.Run` and `Import` methods. [[1]](diffhunk://#diff-946b14507f16234d8b1314943d601b403a66305004afbf320ef33cf46d51861cL176-R176) [[2]](diffhunk://#diff-946b14507f16234d8b1314943d601b403a66305004afbf320ef33cf46d51861cL185-R185)

### New `PooledMongoRunner` Class:
* [`src/EphemeralMongo/PooledMongoRunner.cs`](diffhunk://#diff-5a9c3853745399bd1269dca42f9c94d65e9c4252e2b9fdaec7a895654a47372fR1-R188): Introduced a new `PooledMongoRunner` class that manages a pool of `MongoRunner` instances, allowing for efficient reuse and disposal of runners.
* [`src/EphemeralMongo.Tests/PooledMongoRunnerTests.cs`](diffhunk://#diff-7e6a8342b46ef714142db9730a6c916eb0d3a8afab424afaacc613e6bd53570cR1-R312): Added extensive tests for the `PooledMongoRunner` class, covering various scenarios such as renting, returning, and disposing runners.

### Experimental Attribute:
* [`src/EphemeralMongo/ExperimentalAttribute.cs`](diffhunk://#diff-adbfbd3473ff4aff0fb480496c5dc9a47f8e1520b5c71e54dd9e51ca332e37d7R1-R38): Added an `ExperimentalAttribute` for marking experimental features, which is conditionally compiled for .NET versions earlier than 8.0.

These changes collectively enhance the functionality and maintainability of the `EphemeralMongo` project by introducing support for cancellation tokens, improving resource management through pooling, and providing a mechanism for marking experimental features.