### PR TITLE
Improve troubleshooting experience on unexpected process exit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04, windows-2022, macos-14]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/EphemeralMongo.Tests/MongoRunnerTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerTests.cs
@@ -202,6 +202,25 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
             File.Delete(exportedFilePath);
         }
     }
+    [Fact]
+    public async Task Run_Fails_When_InvalidArgument_And_Provides_Details_In_Exception()
+    {
+        var options = new MongoRunnerOptions
+        {
+            Version = MongoVersion.V8,
+            StandardOutputLogger = this.MongoMessageLogger,
+            StandardErrorLogger = this.MongoMessageLogger,
+            AdditionalArguments = ["--invalid-argument"],
+        };
+
+        var ex = await Assert.ThrowsAsync<EphemeralMongoException>(async () =>
+        {
+            using var _ = await MongoRunner.RunAsync(options, testContextAccessor.Current.CancellationToken);
+        });
+
+        testOutputHelper.WriteLine(ex.Message);
+        Assert.Contains("unrecognised option '--invalid-argument'", ex.Message);
+    }
 
     private void MongoMessageLogger(string message)
     {

--- a/src/EphemeralMongo.Tests/MongoRunnerTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerTests.cs
@@ -1,4 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -10,7 +12,7 @@ namespace EphemeralMongo.Tests;
 public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAccessor testContextAccessor)
 {
     [Fact]
-    public async Task Run_Fails_When_BinaryDirectory_Does_Not_Exist()
+    public async Task StartMongo_WithNonExistentBinaryDirectory_ThrowsFileNotFoundException()
     {
         var options = new MongoRunnerOptions
         {
@@ -39,7 +41,7 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
     }
 
     [Fact]
-    public async Task Run_Cleans_Up_Temporary_Data_Directory()
+    public async Task StartMongo_WithTemporaryDataDirectory_CleansUpOldDirectories()
     {
         var rootDataDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
@@ -111,7 +113,7 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
     [InlineData(true, MongoVersion.V6, MongoEdition.Enterprise)]
     [InlineData(true, MongoVersion.V7, MongoEdition.Enterprise)]
     [InlineData(true, MongoVersion.V8, MongoEdition.Enterprise)]
-    public async Task Import_Export_Works(bool replset, MongoVersion version, MongoEdition edition)
+    public async Task MongoOperations_ImportAndExport_SucceedsAcrossInstances(bool replset, MongoVersion version, MongoEdition edition)
     {
         if (version is MongoVersion.V6 or MongoVersion.V7 && edition == MongoEdition.Enterprise && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {
@@ -202,8 +204,9 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
             File.Delete(exportedFilePath);
         }
     }
+
     [Fact]
-    public async Task Run_Fails_When_InvalidArgument_And_Provides_Details_In_Exception()
+    public async Task StartMongo_WithInvalidArgument_ThrowsExceptionWithDetails()
     {
         var options = new MongoRunnerOptions
         {
@@ -220,6 +223,42 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
 
         testOutputHelper.WriteLine(ex.Message);
         Assert.Contains("unrecognised option '--invalid-argument'", ex.Message);
+    }
+
+    [Fact]
+    public async Task StartMongo_WithPortInUse_ThrowsExceptionWithDetails()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, port: 0);
+
+        try
+        {
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+
+            var options = new MongoRunnerOptions
+            {
+                Version = MongoVersion.V8,
+                StandardOutputLogger = testOutputHelper.WriteLine,
+                StandardErrorLogger = testOutputHelper.WriteLine,
+                AdditionalArguments = ["--quiet"],
+                MongoPort = port,
+            };
+
+            var ex = await Assert.ThrowsAsync<EphemeralMongoException>(async () =>
+            {
+                using var _ = await MongoRunner.RunAsync(options, testContextAccessor.Current.CancellationToken);
+            });
+
+            testOutputHelper.WriteLine(ex.Message);
+
+            // Full message looks like this:
+            // The MongoDB process '<omitted>' exited unexpectedly with code 48. Output:{"t":{"$date":"2025-04-18T22:44:09.346-04:00"},"s":"E",  "c":"CONTROL",  "id":20568,   "ctx":"initandlisten","msg":"Error setting up listener","attr":{"error":{"code":9001,"codeName":"SocketException","errmsg":"127.0.0.1:60912 :: caused by :: setup bind :: caused by :: An attempt was made to access a socket in a way forbidden by its access permissions."}}}
+            Assert.Contains("SocketException", ex.Message);
+        }
+        finally
+        {
+            listener.Stop();
+        }
     }
 
     private void MongoMessageLogger(string message)

--- a/src/EphemeralMongo/BaseMongoProcess.cs
+++ b/src/EphemeralMongo/BaseMongoProcess.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 
 namespace EphemeralMongo;
 
@@ -18,6 +19,8 @@ internal abstract class BaseMongoProcess : IMongoProcess
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
+            StandardOutputEncoding = Encoding.UTF8,
+            StandardErrorEncoding = Encoding.UTF8,
         };
 
         this.Process = new Process

--- a/src/EphemeralMongo/Download/FileCompressionHelper.cs
+++ b/src/EphemeralMongo/Download/FileCompressionHelper.cs
@@ -30,7 +30,7 @@ internal static class FileCompressionHelper
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"Failed to extract zip file {archiveFilePath} to {destinationDirectory}", ex);
+            throw new EphemeralMongoException($"Failed to extract zip file {archiveFilePath} to {destinationDirectory}", ex);
         }
     }
 
@@ -48,7 +48,7 @@ internal static class FileCompressionHelper
 
         if (Process.Start(processStartInfo) is not { } process)
         {
-            throw new InvalidOperationException($"Failed to start the tar process to extract {archiveFilePath} to {destinationDirectory}");
+            throw new EphemeralMongoException($"Failed to start the tar process to extract {archiveFilePath} to {destinationDirectory}");
         }
 
         try
@@ -95,7 +95,7 @@ internal static class FileCompressionHelper
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"Failed to extract tar.gz file {archiveFilePath} to {destinationDirectory}", ex);
+            throw new EphemeralMongoException($"Failed to extract tar.gz file {archiveFilePath} to {destinationDirectory}", ex);
         }
     }
 }

--- a/src/EphemeralMongo/Download/FileHashHelper.cs
+++ b/src/EphemeralMongo/Download/FileHashHelper.cs
@@ -33,12 +33,12 @@ internal static class FileHashHelper
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"Failed to compute SHA256 hash for file {filePath}", ex);
+            throw new EphemeralMongoException($"Failed to compute SHA256 hash for file {filePath}", ex);
         }
 
         if (!hash.Equals(expectedHash, StringComparison.OrdinalIgnoreCase))
         {
-            throw new InvalidOperationException($"The hash of the downloaded file {filePath} does not match the expected hash. Expected: {expectedHash}, Actual: {hash}");
+            throw new EphemeralMongoException($"The hash of the downloaded file {filePath} does not match the expected hash. Expected: {expectedHash}, Actual: {hash}");
         }
 
 #if NETSTANDARD2_0

--- a/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
+++ b/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
@@ -63,10 +63,10 @@ internal static class MongoExecutableDownloader
             var mongodVersions = await options.Transport.GetFromJsonAsync<MongoVersionsDto>("https://downloads.mongodb.org/current.json", cancellationToken).ConfigureAwait(false);
 
             var mongodVersion = mongodVersions.Versions.FirstOrDefault(x => x.ProductionRelease && x.Version.StartsWith(majorVersion.ToString(CultureInfo.InvariantCulture), StringComparison.Ordinal))
-                ?? throw new InvalidOperationException($"Could not find a production release for MongoDB major version {majorVersion}");
+                ?? throw new EphemeralMongoException($"Could not find a production release for MongoDB major version {majorVersion}");
 
             var mongodDownload = mongodVersion.Downloads.SingleOrDefault(x => x.Architecture == architecture && x.Edition == edition && x.Target == target)
-                ?? throw new InvalidOperationException($"Could not find a production release for MongoDB architecture {architecture}, edition {edition}, and target {target}");
+                ?? throw new EphemeralMongoException($"Could not find a production release for MongoDB architecture {architecture}, edition {edition}, and target {target}");
 
             var exeDirPath = Path.Combine(baseExeDirPath, mongodVersion.Version);
             var exeFilePath = Path.Combine(exeDirPath, MongodExeFileName);
@@ -95,14 +95,14 @@ internal static class MongoExecutableDownloader
                 var tmpUncompressedFirstDirPath = Directory.GetDirectories(tmpUncompressDirPath);
                 if (tmpUncompressedFirstDirPath.Length != 1)
                 {
-                    throw new InvalidOperationException($"There should be only one directory in {tmpUncompressDirPath}, but found {tmpUncompressedFirstDirPath.Length}");
+                    throw new EphemeralMongoException($"There should be only one directory in {tmpUncompressDirPath}, but found {tmpUncompressedFirstDirPath.Length}");
                 }
 
                 var tmpExeDirPath = Path.Combine(tmpUncompressedFirstDirPath[0], "bin");
                 var tmpExeFilePath = Path.Combine(tmpExeDirPath, MongodExeFileName);
                 if (!File.Exists(tmpExeFilePath))
                 {
-                    throw new InvalidOperationException($"The executable file {tmpExeFilePath} could not be copied to {exeFilePath} because it does not exist");
+                    throw new EphemeralMongoException($"The executable file {tmpExeFilePath} could not be copied to {exeFilePath} because it does not exist");
                 }
 
                 Directory.CreateDirectory(exeDirPath);
@@ -173,10 +173,10 @@ internal static class MongoExecutableDownloader
             var mongoToolsVersions = await options.Transport.GetFromJsonAsync<ToolsVersionsDto>("https://downloads.mongodb.org/tools/db/release.json", cancellationToken).ConfigureAwait(false);
 
             var mongoToolsVersion = mongoToolsVersions.Versions.FirstOrDefault()
-                ?? throw new InvalidOperationException($"Could not find the latest MongoDB tools version");
+                ?? throw new EphemeralMongoException($"Could not find the latest MongoDB tools version");
 
             var mongoToolsDownload = mongoToolsVersion.Downloads.SingleOrDefault(x => x.Architecture == architecture && x.Name == target)
-                ?? throw new InvalidOperationException($"Could not find the latest MongoDB tools version for architecture {architecture} and target {target}");
+                ?? throw new EphemeralMongoException($"Could not find the latest MongoDB tools version for architecture {architecture} and target {target}");
 
             var exeDirPath = Path.Combine(baseExeDirPath, mongoToolsVersion.Version);
             var mongoImportExeFilePath = Path.Combine(exeDirPath, MongoImportExeFileName);
@@ -207,7 +207,7 @@ internal static class MongoExecutableDownloader
                 var tmpUncompressedFirstDirPath = Directory.GetDirectories(tmpUncompressDirPath);
                 if (tmpUncompressedFirstDirPath.Length != 1)
                 {
-                    throw new InvalidOperationException($"There should be only one directory in {tmpUncompressDirPath}, but found {tmpUncompressedFirstDirPath.Length}");
+                    throw new EphemeralMongoException($"There should be only one directory in {tmpUncompressDirPath}, but found {tmpUncompressedFirstDirPath.Length}");
                 }
 
                 var tmpMongoImportExeFilePath = Path.Combine(tmpUncompressedFirstDirPath[0], "bin", MongoImportExeFileName);
@@ -215,7 +215,7 @@ internal static class MongoExecutableDownloader
 
                 if (!File.Exists(tmpMongoImportExeFilePath) || !File.Exists(tmpMongoExportExeFilePath))
                 {
-                    throw new InvalidOperationException($"The executable files {tmpMongoImportExeFilePath} and {tmpMongoExportExeFilePath} could not be copied to {exeDirPath} because they do not exist");
+                    throw new EphemeralMongoException($"The executable files {tmpMongoImportExeFilePath} and {tmpMongoExportExeFilePath} could not be copied to {exeDirPath} because they do not exist");
                 }
 
                 SafeFileCopy(tmpMongoImportExeFilePath, mongoImportExeFilePath);
@@ -263,7 +263,7 @@ internal static class MongoExecutableDownloader
         }
         catch (IOException ex)
         {
-            throw new InvalidOperationException($"The directory {exeDirPath} did not contain the expected executable file {MongodExeFileName} and could not be deleted. Please delete it first.", ex);
+            throw new EphemeralMongoException($"The directory {exeDirPath} did not contain the expected executable file {MongodExeFileName} and could not be deleted. Please delete it first.", ex);
         }
 
         return null;
@@ -292,7 +292,7 @@ internal static class MongoExecutableDownloader
         }
         catch (IOException ex)
         {
-            throw new InvalidOperationException($"The directory {exeDirPath} did not contain the expected executable files {MongoImportExeFileName} and {MongoExportExeFileName} and could not be deleted. Please delete it first.", ex);
+            throw new EphemeralMongoException($"The directory {exeDirPath} did not contain the expected executable files {MongoImportExeFileName} and {MongoExportExeFileName} and could not be deleted. Please delete it first.", ex);
         }
 
         return null;

--- a/src/EphemeralMongo/EphemeralMongoException.cs
+++ b/src/EphemeralMongo/EphemeralMongoException.cs
@@ -1,0 +1,14 @@
+﻿namespace EphemeralMongo;
+
+public sealed class EphemeralMongoException : Exception
+{
+    public EphemeralMongoException(string message)
+        : base(message)
+    {
+    }
+
+    public EphemeralMongoException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/EphemeralMongo/FileSystem.cs
+++ b/src/EphemeralMongo/FileSystem.cs
@@ -34,6 +34,38 @@ internal sealed class FileSystem : IFileSystem
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
+#if NET8_0_OR_GREATER
+            try
+            {
+                var unixMode = File.GetUnixFileMode(path);
+                var alreadyExecutable = unixMode.HasFlag(UnixFileMode.UserExecute) || unixMode.HasFlag(UnixFileMode.GroupExecute) || unixMode.HasFlag(UnixFileMode.OtherExecute);
+                if (alreadyExecutable)
+                {
+                    return;
+                }
+            }
+            catch
+            {
+                // If test command fails (not found, etc.), fall through to chmod
+            }
+#else
+            try
+            {
+                using var testProcess = Process.Start("test", "-x " + ProcessArgument.Escape(path));
+                testProcess?.WaitForExit();
+
+                var alreadyExecutable = testProcess?.ExitCode == 0;
+                if (alreadyExecutable)
+                {
+                    return;
+                }
+            }
+            catch
+            {
+                // If test command fails (not found, etc.), fall through to chmod
+            }
+#endif
+
             // Do not throw if exit code is not equal to zero.
             // If there's something wrong with the path or permissions, we'll see it later.
             using var chmod = Process.Start("chmod", "+x " + ProcessArgument.Escape(path));

--- a/src/EphemeralMongo/HttpTransport.cs
+++ b/src/EphemeralMongo/HttpTransport.cs
@@ -62,7 +62,7 @@ public sealed class HttpTransport
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"An error occurred while downloading the file from {url} to {filePath}", ex);
+            throw new EphemeralMongoException($"An error occurred while downloading the file from {url} to {filePath}", ex);
         }
     }
 
@@ -88,9 +88,9 @@ public sealed class HttpTransport
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"An error occurred while parsing {url} as a JSON response", ex);
+            throw new EphemeralMongoException($"An error occurred while parsing {url} as a JSON response", ex);
         }
 
-        return value ?? throw new InvalidOperationException($"An error occurred while parsing {url} as a JSON response");
+        return value ?? throw new EphemeralMongoException($"An error occurred while parsing {url} as a JSON response");
     }
 }

--- a/src/EphemeralMongo/MongodProcess.cs
+++ b/src/EphemeralMongo/MongodProcess.cs
@@ -150,7 +150,7 @@ internal sealed class MongodProcess : BaseMongoProcess
         void OnProcessExited(object? sender, EventArgs e)
         {
             isReplicaSetReadyTcs.TrySetResult(false);
-            isReplicaSetReadyTcs.TrySetResult(false);
+            isTransactionReadyTcs.TrySetResult(false);
         }
 
         void OnClusterDescriptionChanged(ClusterDescriptionChangedEvent evt)

--- a/src/EphemeralMongo/MongodProcess.cs
+++ b/src/EphemeralMongo/MongodProcess.cs
@@ -1,5 +1,8 @@
 ﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text;
+using System.Text.RegularExpressions;
 using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Events;
@@ -7,9 +10,19 @@ using MongoDB.Driver.Core.Servers;
 
 namespace EphemeralMongo;
 
+#if NET8_0_OR_GREATER
+internal sealed partial class MongodProcess : BaseMongoProcess
+#else
 internal sealed class MongodProcess : BaseMongoProcess
+#endif
 {
     private const string ConnectionReadySentence = "waiting for connections";
+
+    // https://github.com/search?q=%22STATUS_DLL_NOT_FOUND%22+%223221225781%22&type=code
+    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "STATUS_DLL_NOT_FOUND is a constant from the Windows API")]
+    private const uint STATUS_DLL_NOT_FOUND = 3221225781; // "-1073741515" as a signed int returned by Process.ExitCode
+
+    private readonly StringBuilder _startupErrors = new StringBuilder();
 
     public MongodProcess(MongoRunnerOptions options, string executablePath, string[] arguments)
         : base(options, executablePath, arguments)
@@ -18,11 +31,24 @@ internal sealed class MongodProcess : BaseMongoProcess
 
     public override async Task StartAsync(CancellationToken cancellationToken)
     {
-        await this.StartAndWaitForConnectionReadinessAsync(cancellationToken).ConfigureAwait(false);
+        this.Process.OutputDataReceived += this.OnOutputDataReceivedCaptureStartupErrors;
+        this.Process.ErrorDataReceived += this.OnErrorDataReceivedCaptureStartupErrors;
 
-        if (this.Options.UseSingleNodeReplicaSet)
+        try
         {
-            await this.ConfigureAndWaitForReplicaSetReadinessAsync(cancellationToken).ConfigureAwait(false);
+            await this.StartAndWaitForConnectionReadinessAsync(cancellationToken).ConfigureAwait(false);
+
+            if (this.Options.UseSingleNodeReplicaSet)
+            {
+                await this.ConfigureAndWaitForReplicaSetReadinessAsync(cancellationToken).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            this.Process.OutputDataReceived -= this.OnOutputDataReceivedCaptureStartupErrors;
+            this.Process.ErrorDataReceived -= this.OnErrorDataReceivedCaptureStartupErrors;
+
+            this._startupErrors.Clear();
         }
     }
 
@@ -45,11 +71,7 @@ internal sealed class MongodProcess : BaseMongoProcess
 
         void OnProcessExited(object? sender, EventArgs e)
         {
-            var exception = this.Process.ExitCode == 0
-                ? new InvalidOperationException($"The process MongoDB process {this.Process.Id} exited unexpectedly.")
-                : new InvalidOperationException($"The process MongoDB process {this.Process.Id} exited unexpectedly with code {this.Process.ExitCode}.");
-
-            isReadyToAcceptConnectionsTcs.TrySetException(exception);
+            isReadyToAcceptConnectionsTcs.TrySetResult(false);
         }
 
         this.Process.OutputDataReceived += OnOutputDataReceivedForConnectionReadiness;
@@ -80,6 +102,8 @@ internal sealed class MongodProcess : BaseMongoProcess
 
                     throw new TimeoutException(timeoutMessage, ex);
                 }
+
+                this.HandleUnexpectedProcessExit();
             }
         }
         finally
@@ -89,6 +113,35 @@ internal sealed class MongodProcess : BaseMongoProcess
         }
     }
 
+    private void HandleUnexpectedProcessExit()
+    {
+        if (this.Process.HasExited)
+        {
+            // WaitForExit ensure that all output is flushed before we throw the exception,
+            // ensuring we asynchronously capture all standard output and error messages.
+            this.Process.WaitForExit();
+            throw this.CreateExceptionFromUnexpectedProcessExit();
+        }
+    }
+
+    private EphemeralMongoException CreateExceptionFromUnexpectedProcessExit()
+    {
+        var exitCode = (uint)this.Process.ExitCode;
+        var processDescription = $"{this.Process.StartInfo.FileName} {this.Process.StartInfo.Arguments}";
+        var startupErrors = this._startupErrors.ToString();
+        var startupErrorsMessage = string.IsNullOrWhiteSpace(startupErrors) ? string.Empty : $" Output: {startupErrors}";
+
+        return exitCode switch
+        {
+            0 => new EphemeralMongoException($"The MongoDB process '{processDescription}' exited unexpectedly.{startupErrorsMessage}"),
+
+            // Happens on Windows for MongoDB Enterprise edition when sasl2.dll is missing
+            STATUS_DLL_NOT_FOUND => new EphemeralMongoException($"The MongoDB process '{processDescription}' exited unexpectedly with code {exitCode}. This is likely due to a missing DLL.{startupErrorsMessage}"),
+
+            _ => new EphemeralMongoException($"The MongoDB process '{processDescription}' exited unexpectedly with code {exitCode}.{startupErrorsMessage}")
+        };
+    }
+
     private async Task ConfigureAndWaitForReplicaSetReadinessAsync(CancellationToken cancellationToken)
     {
         var isReplicaSetReadyTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -96,12 +149,8 @@ internal sealed class MongodProcess : BaseMongoProcess
 
         void OnProcessExited(object? sender, EventArgs e)
         {
-            var exception = this.Process.ExitCode == 0
-                ? new InvalidOperationException($"The process MongoDB process {this.Process.Id} exited unexpectedly.")
-                : new InvalidOperationException($"The process MongoDB process {this.Process.Id} exited unexpectedly with code {this.Process.ExitCode}.");
-
-            isReplicaSetReadyTcs.TrySetException(exception);
-            isTransactionReadyTcs.TrySetException(exception);
+            isReplicaSetReadyTcs.TrySetResult(false);
+            isReplicaSetReadyTcs.TrySetResult(false);
         }
 
         void OnClusterDescriptionChanged(ClusterDescriptionChangedEvent evt)
@@ -202,6 +251,8 @@ internal sealed class MongodProcess : BaseMongoProcess
 
                     throw new TimeoutException(timeoutMessage);
                 }
+
+                this.HandleUnexpectedProcessExit();
             }
         }
         finally
@@ -209,4 +260,49 @@ internal sealed class MongodProcess : BaseMongoProcess
             this.Process.Exited -= OnProcessExited;
         }
     }
+
+    private void OnOutputDataReceivedCaptureStartupErrors(object sender, DataReceivedEventArgs args)
+    {
+        if (args.Data == null)
+        {
+            return;
+        }
+
+        if (LogMessageRegex.Match(args.Data) is { Success: true } match)
+        {
+            if (match.Groups["severity"].Value is "E" or "F")
+            {
+                this._startupErrors.AppendLine(match.Groups["msg"].Value);
+            }
+        }
+        else
+        {
+            // Startup error messages (like invalid arguments) are also sent to standard output as plain text
+            this._startupErrors.AppendLine(args.Data);
+        }
+    }
+
+    private void OnErrorDataReceivedCaptureStartupErrors(object sender, DataReceivedEventArgs args)
+    {
+        if (args.Data != null)
+        {
+            this._startupErrors.AppendLine(args.Data);
+        }
+    }
+
+    // The regex is used to parse the log messages from MongoDB. I wanted to avoid a dependency on System.Text.Json.
+    // This works as long as message doesn't contain quotes, but I haven't seen that yet, especially in the startup errors messages.
+    // https://www.mongodb.com/docs/manual/reference/log-messages/
+#if NET8_0_OR_GREATER
+    private static readonly Regex LogMessageRegex = CreateLogMessageRegex();
+
+    [GeneratedRegex(
+        @"^\{""t"":\{""\$date"":""[^""]+""\},\s*""s"":""(?<severity>[^""]+)"",\s*""c"":""[^""]+"",\s*""id"":\d+,\s*""ctx"":""[^""]+"",\s*""msg"":""(?<msg>[^""]+)""",
+        RegexOptions.ExplicitCapture | RegexOptions.Singleline)]
+    private static partial Regex CreateLogMessageRegex();
+#else
+    private static readonly Regex LogMessageRegex = new Regex(
+        @"^\{""t"":\{""\$date"":""[^""]+""\},\s*""s"":""(?<severity>[^""]+)"",\s*""c"":""[^""]+"",\s*""id"":\d+,\s*""ctx"":""[^""]+"",\s*""msg"":""(?<msg>[^""]+)""",
+        RegexOptions.ExplicitCapture | RegexOptions.Singleline);
+#endif
 }

--- a/src/EphemeralMongo/PublicAPI.Shipped.txt
+++ b/src/EphemeralMongo/PublicAPI.Shipped.txt
@@ -1,4 +1,7 @@
 #nullable enable
+EphemeralMongo.EphemeralMongoException
+EphemeralMongo.EphemeralMongoException.EphemeralMongoException(string! message) -> void
+EphemeralMongo.EphemeralMongoException.EphemeralMongoException(string! message, System.Exception! innerException) -> void
 EphemeralMongo.HttpTransport
 EphemeralMongo.HttpTransport.HttpTransport(System.Net.Http.HttpClient! httpClient) -> void
 EphemeralMongo.HttpTransport.HttpTransport(System.Net.Http.HttpMessageHandler! handler) -> void


### PR DESCRIPTION
The general idea is to **help developers understand what happens when an unexpected exception occurs**.

Fixes #55 

- Improved the message of exceptions thrown at startup:
  - Include the full process path and arguments.
  - Include error and fatal structed log messages from `mongod`.
  - Include standard error, and sometimes standard output (e.g., when invalid arguments are passed to `mood`).
- Throw a new `EphemeralMongoException` type for unexpected behavior, like errors downloading the binaries or errors starting processes. Other built-in exceptions, like `ArgumentException`, `TimeoutException`, and `NotSupportedException`, remain used for specific use cases.
- Use UTF-8 for MongoDB standard output and error.
- Bonus change: check if mongod if already executable to skip chmod +x
- Bonus change: disabled fail fast in CI matrix

**Exception message on Ubuntu 24.04 when `libldap2` isn't installed**:

> The MongoDB process '/home/<omitted>/.local/share/ephemeral-mongo/bin/mongod/mongod-enterprise-8/8.0.8/mongod --dbpath /tmp/ephemeral-mongo/data/taufliai.hed --port 42995 --bind_ip 127.0.0.1 --quiet' exited unexpectedly with code 127. Output: /home/<omitted>/.local/share/ephemeral-mongo/bin/mongod/mongod-enterprise-8/8.0.8/mongod: error while loading shared libraries: libcurl.so.4: cannot open shared object file: No such file or directory

**Exception message on Windows when sasl2.dll is missing**:

> The MongoDB process 'C:\Users\<omitted>\AppData\Local\ephemeral-mongo\bin\mongod\mongod-enterprise-8\8.0.8\mongod.exe --dbpath C:\Users\<omitted>\AppData\Local\Temp\ephemeral-mongo\data\pwbaopph.m2n --port 54966 --bind_ip 127.0.0.1 --tlsMode disabled --replSet singleNodeReplSet --quiet --storageEngine inMemory' exited unexpectedly with code 3221225781. This is likely due to a missing DLL.

**Exception message on invalid `mongod` argument**:

> The MongoDB process 'C:\Users\<omitted>\AppData\Local\ephemeral-mongo\bin\mongod\mongod-base-8\8.0.8\mongod.exe --dbpath C:\Users\<omitted>\AppData\Local\Temp\ephemeral-mongo\data\cqlpej3p.hkd --port 55061 --bind_ip 127.0.0.1 --tlsMode disabled --invalid-argument' exited unexpectedly with code 2. Output: Error parsing command line: unrecognised option '--invalid-argument'
try 'C:\Users\<omitted>\AppData\Local\ephemeral-mongo\bin\mongod\mongod-base-8\8.0.8\mongod.exe --help' for more information

**Exception message on port already in use**:

> The MongoDB process 'C:\Users\<omitted>\AppData\Local\ephemeral-mongo\bin\mongod\mongod-base-8\8.0.8\mongod.exe --dbpath C:\Users\<omitted>\AppData\Local\Temp\ephemeral-mongo\data\nsir234g.ts2 --port 52498 --bind_ip 127.0.0.1 --tlsMode disabled --quiet' exited unexpectedly with code 48. Output: {"t":{"$date":"2025-04-18T23:16:52.462-04:00"},"s":"E",  "c":"CONTROL",  "id":20568,   "ctx":"initandlisten","msg":"Error setting up listener","attr":{"error":{"code":9001,"codeName":"SocketException","errmsg":"127.0.0.1:52498 :: caused by :: setup bind :: caused by :: An attempt was made to access a socket in a way forbidden by its access permissions."}}}