### PR TITLE
An attempt to reduce flakiness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, macos-14, windows-2025]
+        os: [ubuntu-24.04, ubuntu-22.04, macos-14, windows-2019]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, macos-14, windows-2019, windows-2022, windows-2025]
+        os: [ubuntu-24.04, ubuntu-22.04, macos-14, windows-2025]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, windows-2022, macos-14]
+        os: [ubuntu-24.04, ubuntu-22.04, macos-14, windows-2019, windows-2022, windows-2025]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/src/EphemeralMongo.Tests/MongoRunnerPoolTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerPoolTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.InteropServices;
-using MongoDB.Bson;
+﻿using MongoDB.Bson;
 using MongoDB.Driver;
 
 #pragma warning disable EMEX0001 // Type is for evaluation purposes only

--- a/src/EphemeralMongo.Tests/MongoRunnerPoolTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerPoolTests.cs
@@ -317,15 +317,6 @@ public class MongoRunnerPoolTests(ITestContextAccessor testContextAccessor)
     private static IMongoDatabase GetAdminDatabase(string connectionString)
     {
         var clientSettings = MongoClientSettings.FromConnectionString(connectionString);
-
-        // Tests on Windows are a little slower than Linux and macOS
-        var timeout = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? TimeSpan.FromSeconds(5) : TimeSpan.FromSeconds(2);
-
-        clientSettings.ConnectTimeout = timeout;
-        clientSettings.HeartbeatTimeout = timeout;
-        clientSettings.SocketTimeout = timeout;
-        clientSettings.ServerSelectionTimeout = timeout;
-
         return new MongoClient(clientSettings).GetDatabase("admin");
     }
 }

--- a/src/EphemeralMongo.v2/EphemeralMongo.v2.csproj
+++ b/src/EphemeralMongo.v2/EphemeralMongo.v2.csproj
@@ -32,7 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GitVersion.MsBuild" Condition=" '$(Configuration)' == 'Release' ">
+    <PackageReference Include="GitVersion.MsBuild" Condition=" '$(Configuration)' == 'Release' AND !$([MSBuild]::IsOsPlatform('OSX')) ">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
+++ b/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
@@ -245,6 +245,7 @@ internal static class MongoExecutableDownloader
         {
             try
             {
+                // An IO conflict happened in Windows CI where the file was edited by another process (multi-assembly testing)
 #if NETSTANDARD2_0
                 File.Create(lastCheckFilePath).Dispose();
 #else
@@ -256,18 +257,12 @@ internal static class MongoExecutableDownloader
             {
                 if (attempt == maxAttempts)
                 {
-                    // Rethrow on the last attempt
                     throw;
                 }
 
                 await Task.Delay(retryDelayMs).ConfigureAwait(false);
             }
         }
-    }
-
-    private static void UpdateLastCheckFile(string lastCheckFilePath)
-    {
-        File.Create(lastCheckFilePath).Dispose();
     }
 
     private static string? FindLatestExistingMongodExeFilePath(string baseExeDirPath)

--- a/src/EphemeralMongo/EphemeralMongo.csproj
+++ b/src/EphemeralMongo/EphemeralMongo.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GitVersion.MsBuild" Condition=" '$(Configuration)' == 'Release' AND $([MSBuild]::IsOsPlatform('Linux')) ">
+    <PackageReference Include="GitVersion.MsBuild" Condition=" '$(Configuration)' == 'Release' AND !$([MSBuild]::IsOsPlatform('OSX')) ">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/EphemeralMongo/EphemeralMongo.csproj
+++ b/src/EphemeralMongo/EphemeralMongo.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="GitVersion.MsBuild" Condition=" '$(Configuration)' == 'Release' ">
+    <PackageReference Include="GitVersion.MsBuild" Condition=" '$(Configuration)' == 'Release' AND $([MSBuild]::IsOsPlatform('Linux')) ">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/EphemeralMongo/FileSystem.cs
+++ b/src/EphemeralMongo/FileSystem.cs
@@ -42,15 +42,15 @@ internal sealed class FileSystem : IFileSystem
         try
         {
 #if NET8_0_OR_GREATER
-            // const UnixFileMode executePermissions = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+            const UnixFileMode executePermissions = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
 
-            // var unixFileMode = File.GetUnixFileMode(path);
-            // var alreadyExecutable = (unixFileMode & executePermissions) != UnixFileMode.None;
+            var unixFileMode = File.GetUnixFileMode(path);
+            var alreadyExecutable = (unixFileMode & executePermissions) != UnixFileMode.None;
 
-            // if (!alreadyExecutable)
-            // {
-            //     File.SetUnixFileMode(path, unixFileMode | executePermissions);
-            // }
+            if (!alreadyExecutable)
+            {
+                File.SetUnixFileMode(path, unixFileMode | executePermissions);
+            }
 #else
             using var test = Process.Start("test", "-x " + ProcessArgument.Escape(path));
             test?.WaitForExit();

--- a/src/EphemeralMongo/FileSystem.cs
+++ b/src/EphemeralMongo/FileSystem.cs
@@ -42,15 +42,15 @@ internal sealed class FileSystem : IFileSystem
         try
         {
 #if NET8_0_OR_GREATER
-            const UnixFileMode executePermissions = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
+            // const UnixFileMode executePermissions = UnixFileMode.UserExecute | UnixFileMode.GroupExecute | UnixFileMode.OtherExecute;
 
-            var unixFileMode = File.GetUnixFileMode(path);
-            var alreadyExecutable = (unixFileMode & executePermissions) != UnixFileMode.None;
+            // var unixFileMode = File.GetUnixFileMode(path);
+            // var alreadyExecutable = (unixFileMode & executePermissions) != UnixFileMode.None;
 
-            if (!alreadyExecutable)
-            {
-                File.SetUnixFileMode(path, unixFileMode | executePermissions);
-            }
+            // if (!alreadyExecutable)
+            // {
+            //     File.SetUnixFileMode(path, unixFileMode | executePermissions);
+            // }
 #else
             using var test = Process.Start("test", "-x " + ProcessArgument.Escape(path));
             test?.WaitForExit();


### PR DESCRIPTION
- Use Unix File APIs on .NET 8+ instead of starting `chmod +x` and `test +x`
- Retry `Process.Start` when an exception happens with _text file busy_
- Detect that MongoDB is down using `TcpListener`
- Skip GitVersion on macOS as it sometimes fails on CI
- Retry updating the check file when downloading binaries