### PR TITLE
Make Windows CI less flaky by reducing the amount of tests to a minimum

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -26,9 +26,13 @@ Process {
 
     # https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-integration-dotnet-test
     # https://github.com/microsoft/testfx/issues/4396
-    Exec { & dotnet test  -c Release --no-build --no-restore -p:TestingPlatformShowTestsFailure=true -p:TestingPlatformCaptureOutput=false -tl:false }
+    if ($IsWindows) {
+      Exec { & dotnet test -c Release --no-build --no-restore -p:TestingPlatformShowTestsFailure=true -p:TestingPlatformCaptureOutput=false -tl:false -- --filter-query "/[Category!=SlowOnWindows]" }
+    } else {
+      Exec { & dotnet test -c Release --no-build --no-restore -p:TestingPlatformShowTestsFailure=true -p:TestingPlatformCaptureOutput=false -tl:false }
+    }
 
-    Exec { & dotnet pack  -c Release --no-build --output "$outputDir" }
+    Exec { & dotnet pack -c Release --no-build --output "$outputDir" }
 
     if (($null -ne $env:NUGET_SOURCE ) -and ($null -ne $env:NUGET_API_KEY)) {
       Exec { & dotnet nuget push "$nupkgsPath" -s $env:NUGET_SOURCE -k $env:NUGET_API_KEY --skip-duplicate }

--- a/src/EphemeralMongo.Tests/MongoRunnerPoolTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerPoolTests.cs
@@ -7,6 +7,7 @@ using MongoDB.Driver;
 
 namespace EphemeralMongo.Tests;
 
+[Trait(XunitConstants.Category, XunitConstants.SlowOnWindows)]
 public class MongoRunnerPoolTests(ITestContextAccessor testContextAccessor)
 {
     [Fact]

--- a/src/EphemeralMongo.Tests/MongoRunnerTests.cs
+++ b/src/EphemeralMongo.Tests/MongoRunnerTests.cs
@@ -41,6 +41,7 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
     }
 
     [Fact]
+    [Trait(XunitConstants.Category, XunitConstants.SlowOnWindows)]
     public async Task StartMongo_WithTemporaryDataDirectory_CleansUpOldDirectories()
     {
         var rootDataDirectoryPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
@@ -101,19 +102,38 @@ public class MongoRunnerTests(ITestOutputHelper testOutputHelper, ITestContextAc
     }
 
     [Theory]
-    [InlineData(false, MongoVersion.V6, MongoEdition.Community)]
-    [InlineData(false, MongoVersion.V7, MongoEdition.Community)]
-    [InlineData(false, MongoVersion.V8, MongoEdition.Community)]
-    [InlineData(false, MongoVersion.V6, MongoEdition.Enterprise)]
-    [InlineData(false, MongoVersion.V7, MongoEdition.Enterprise)]
-    [InlineData(false, MongoVersion.V8, MongoEdition.Enterprise)]
-    [InlineData(true, MongoVersion.V6, MongoEdition.Community)]
-    [InlineData(true, MongoVersion.V7, MongoEdition.Community)]
-    [InlineData(true, MongoVersion.V8, MongoEdition.Community)]
-    [InlineData(true, MongoVersion.V6, MongoEdition.Enterprise)]
-    [InlineData(true, MongoVersion.V7, MongoEdition.Enterprise)]
-    [InlineData(true, MongoVersion.V8, MongoEdition.Enterprise)]
-    public async Task MongoOperations_ImportAndExport_SucceedsAcrossInstances(bool replset, MongoVersion version, MongoEdition edition)
+    [Trait(XunitConstants.Category, XunitConstants.SlowOnWindows)]
+    [InlineData(MongoEdition.Community, false)]
+    [InlineData(MongoEdition.Enterprise, false)]
+    [InlineData(MongoEdition.Community, true)]
+    [InlineData(MongoEdition.Enterprise, true)]
+    public async Task Mongo6Operations_ImportAndExport_SucceedsAcrossInstances(MongoEdition edition, bool replset)
+    {
+        await this.MongoOperations_ImportAndExport_SucceedsAcrossInstances(MongoVersion.V6, edition, replset);
+    }
+
+    [Theory]
+    [Trait(XunitConstants.Category, XunitConstants.SlowOnWindows)]
+    [InlineData(MongoEdition.Community, false)]
+    [InlineData(MongoEdition.Enterprise, false)]
+    [InlineData(MongoEdition.Community, true)]
+    [InlineData(MongoEdition.Enterprise, true)]
+    public async Task Mongo7Operations_ImportAndExport_SucceedsAcrossInstances(MongoEdition edition, bool replset)
+    {
+        await this.MongoOperations_ImportAndExport_SucceedsAcrossInstances(MongoVersion.V7, edition, replset);
+    }
+
+    [Theory]
+    [InlineData(MongoEdition.Community, false)]
+    [InlineData(MongoEdition.Enterprise, false)]
+    [InlineData(MongoEdition.Community, true)]
+    [InlineData(MongoEdition.Enterprise, true)]
+    public async Task Mongo8Operations_ImportAndExport_SucceedsAcrossInstances(MongoEdition edition, bool replset)
+    {
+        await this.MongoOperations_ImportAndExport_SucceedsAcrossInstances(MongoVersion.V8, edition, replset);
+    }
+
+    private async Task MongoOperations_ImportAndExport_SucceedsAcrossInstances(MongoVersion version, MongoEdition edition, bool replset)
     {
         if (version is MongoVersion.V6 or MongoVersion.V7 && edition == MongoEdition.Enterprise && RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
         {

--- a/src/EphemeralMongo.Tests/XunitConstants.cs
+++ b/src/EphemeralMongo.Tests/XunitConstants.cs
@@ -1,0 +1,9 @@
+﻿namespace EphemeralMongo.Tests;
+
+internal sealed class XunitConstants
+{
+    public const string Category = nameof(Category);
+
+    // Tests on GitHub Actions with the Windows runner are 4x slower than on Linux
+    public const string SlowOnWindows = nameof(SlowOnWindows);
+}


### PR DESCRIPTION
- Add xunit category trait to filter out specific tests on Windows
- Keep resource-intensive, slow tests that make Windows's CI flaky
- Overall, Windows CI duration should be slower