### PR TITLE
Update runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04, macos-14, windows-2019]
+        os: [ubuntu-24.04, ubuntu-22.04, macos-15, windows-2025]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the CI workflow configuration to use newer operating system versions in the test matrix.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL17-R17): Updated the `matrix.os` list to replace `macos-14` with `macos-15` and `windows-2019` with `windows-2025`.