### PR TITLE
fix: ensure user-provided binary directory returns executable path

### DIFF
--- a/src/EphemeralMongo/MongoExecutableLocator.cs
+++ b/src/EphemeralMongo/MongoExecutableLocator.cs
@@ -44,10 +44,13 @@ internal sealed class MongoExecutableLocator : IMongoExecutableLocator
         if (options.BinaryDirectory != null)
         {
             var userProvidedExecutableFilePath = Path.Combine(options.BinaryDirectory, executableFileName);
+
             if (!File.Exists(userProvidedExecutableFilePath))
             {
                 throw new FileNotFoundException($"The provided binary directory '{options.BinaryDirectory}' does not contain the executable '{executableFileName}'.", userProvidedExecutableFilePath);
             }
+
+            return userProvidedExecutableFilePath;
         }
 
         if (processKind == MongoProcessKind.Mongod)


### PR DESCRIPTION
Fixes #103

This pull request makes a small but important improvement to the `FindMongoExecutablePathAsync` method in `MongoExecutableLocator.cs`. It ensures that the method returns the user-provided executable file path if it exists, instead of continuing to execute further logic unnecessarily.

* [`src/EphemeralMongo/MongoExecutableLocator.cs`](diffhunk://#diff-46f8d7319b053bfbb292602a33a983284d398f7b4e4dec258f5baa715b216011R47-R53): Added a `return` statement to immediately return the `userProvidedExecutableFilePath` if the file exists, improving efficiency and clarity.