### PR TITLE
Add support for .NET Framework

### DIFF
--- a/src/EphemeralMongo.Tests/EphemeralMongo.Tests.csproj
+++ b/src/EphemeralMongo.Tests/EphemeralMongo.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net472;net9.0</TargetFrameworks>
+    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">net9.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/EphemeralMongo.v2/EphemeralMongo.v2.csproj
+++ b/src/EphemeralMongo.v2/EphemeralMongo.v2.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
     <AssemblyName>EphemeralMongo</AssemblyName>
     <RootNamespace>EphemeralMongo</RootNamespace>
     <PackageId>EphemeralMongo.v2</PackageId>
@@ -38,7 +38,8 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="System.Text.Json" />
+    <Using Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/src/EphemeralMongo/Download/DownloadTargetHelper.cs
+++ b/src/EphemeralMongo/Download/DownloadTargetHelper.cs
@@ -235,7 +235,7 @@ internal sealed class DownloadTargetHelper(string linuxOsReleasePath)
     private static string EnsureAtLeastTwoVersionParts(string version)
     {
         // System.Version requires at least two parts (e.g., 18.04)
-#if  NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETFRAMEWORK
         return version.IndexOf(".", StringComparison.Ordinal) == -1 ? $"{version}.0" : version;
 #else
         return version.Contains('.', StringComparison.Ordinal) ? version : $"{version}.0";

--- a/src/EphemeralMongo/Download/FileHashHelper.cs
+++ b/src/EphemeralMongo/Download/FileHashHelper.cs
@@ -4,7 +4,7 @@ namespace EphemeralMongo.Download;
 
 internal static class FileHashHelper
 {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETFRAMEWORK
     public static Task EnsureFileSha256HashAsync(string filePath, string expectedHash, CancellationToken cancellationToken)
 #else
     public static async Task EnsureFileSha256HashAsync(string filePath, string expectedHash, CancellationToken cancellationToken)
@@ -15,7 +15,7 @@ internal static class FileHashHelper
         try
         {
             Stream fileStream;
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETFRAMEWORK
             using (fileStream = File.OpenRead(filePath))
 #else
             await using ((fileStream = File.OpenRead(filePath)).ConfigureAwait(false))
@@ -41,7 +41,7 @@ internal static class FileHashHelper
             throw new EphemeralMongoException($"The hash of the downloaded file {filePath} does not match the expected hash. Expected: {expectedHash}, Actual: {hash}");
         }
 
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETFRAMEWORK
         return Task.CompletedTask;
 #endif
     }

--- a/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
+++ b/src/EphemeralMongo/Download/MongoExecutableDownloader.cs
@@ -246,7 +246,7 @@ internal static class MongoExecutableDownloader
             try
             {
                 // An IO conflict happened in Windows CI where the file was edited by another process (multi-assembly testing)
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETFRAMEWORK
                 File.Create(lastCheckFilePath).Dispose();
 #else
                 await File.Create(lastCheckFilePath).DisposeAsync().ConfigureAwait(false);

--- a/src/EphemeralMongo/EphemeralMongo.csproj
+++ b/src/EphemeralMongo/EphemeralMongo.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;netstandard2.1;net8.0</TargetFrameworks>
     <AssemblyName>EphemeralMongo</AssemblyName>
     <RootNamespace>EphemeralMongo</RootNamespace>
     <PackageId>EphemeralMongo</PackageId>
@@ -33,7 +33,8 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="System.Text.Json" />
+    <Using Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/src/EphemeralMongo/MongodProcess.cs
+++ b/src/EphemeralMongo/MongodProcess.cs
@@ -55,7 +55,7 @@ internal sealed class MongodProcess : BaseMongoProcess
 
         void OnOutputDataReceivedForConnectionReadiness(object sender, DataReceivedEventArgs args)
         {
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NETFRAMEWORK
             var isReadyToAcceptConnections = args.Data != null && args.Data.IndexOf(ConnectionReadySentence, StringComparison.OrdinalIgnoreCase) >= 0;
 #else
             var isReadyToAcceptConnections = args.Data != null && args.Data.Contains(ConnectionReadySentence, StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
Fixes #105

This pull request introduces support for the .NET Framework (`net472`) across multiple projects in the repository, alongside adjustments to conditional compilation directives to accommodate this new target framework. The changes ensure compatibility with both `net472` and existing frameworks like `netstandard` and `net8.0`.

### Framework Targeting Updates:

* [`src/EphemeralMongo.Tests/EphemeralMongo.Tests.csproj`](diffhunk://#diff-97544240949e11489d71e504130de157a06f3da01abba755f750e9f9a8b235f5L3-R4): Updated to target `net472` in addition to `net9.0` when running on Windows. Non-Windows platforms remain on `net9.0`.
* [`src/EphemeralMongo.v2/EphemeralMongo.v2.csproj`](diffhunk://#diff-a549ebb33c8bd9563753932e6ab9512164c3404e6ad56ed44ed157879eecfa80L3-R3): Added `net472` as a target framework, expanding support alongside `netstandard2.0` and `net8.0`.
* [`src/EphemeralMongo/EphemeralMongo.csproj`](diffhunk://#diff-199691c84c0b75b570f9ca410037e016a265f61d62e10a941172a1601ca27309L3-R3): Similarly, added `net472` as a target framework, ensuring compatibility with the .NET Framework.

### Conditional Compilation Adjustments:

* Updated `#if` directives in multiple files (e.g., `DownloadTargetHelper.cs`, `FileHashHelper.cs`, `MongoExecutableDownloader.cs`, and `MongodProcess.cs`) to include `NETFRAMEWORK` alongside `NETSTANDARD2_0`. This ensures proper handling of framework-specific features for `net472`. [[1]](diffhunk://#diff-42268c40230fda98a28fc5e342ec030da3c0bc7c36fa0f24f54ddc4afc89bb34L238-R238) [[2]](diffhunk://#diff-db941751deab77fcc4b85f1564de891eb485dd06d11e827afe327c4996d5b306L7-R7) [[3]](diffhunk://#diff-684fdcb90a4555bc8b1cdaa32dc5842592b74db9260c31465470dbcb56d18f55L249-R249) [[4]](diffhunk://#diff-3898495d99f05183a8ab2456557f483007593e1dc1b9b4ccbfbeb7912f945e51L58-R58)

### Dependency and Code Updates:

* `src/EphemeralMongo.v2/EphemeralMongo.v2.csproj` and `src/EphemeralMongo/EphemeralMongo.csproj`: Adjusted `ItemGroup` conditions to include `System.Text.Json` and `System.Net.Http` for all target frameworks except `net8.0`. [[1]](diffhunk://#diff-a549ebb33c8bd9563753932e6ab9512164c3404e6ad56ed44ed157879eecfa80L41-R43) [[2]](diffhunk://#diff-199691c84c0b75b570f9ca410037e016a265f61d62e10a941172a1601ca27309L36-R38)