### PR TITLE
MongoRunnerOptions: allow null data/bin paths

### DIFF
--- a/src/EphemeralMongo/MongoRunnerOptions.cs
+++ b/src/EphemeralMongo/MongoRunnerOptions.cs
@@ -176,7 +176,7 @@ public sealed class MongoRunnerOptions
     {
         if (path == null)
         {
-            return new ArgumentNullException(nameof(path));
+            return null;
         }
 
         try


### PR DESCRIPTION
The default path for both of these is `null`, so using the setter to set these values to null should not change anything in the behavior.

Allowing nulls here enables the use-case of allowing things such as `new MongoRunnerOptions { BinaryDirectory = Environment.GetEnvironmentVariable("TEST_MONGODB_PATH") }` in order to use `TEST_MONGODB_PATH` if it's set, otherwise fallback to the default behavior.