### PR TITLE
feat: add EphemeralMongo v2.27 and corresponding test project

### DIFF
--- a/src/EphemeralMongo.sln
+++ b/src/EphemeralMongo.sln
@@ -19,6 +19,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EphemeralMongo", "Ephemeral
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EphemeralMongo.Tests", "EphemeralMongo.Tests\EphemeralMongo.Tests.csproj", "{A365BA82-91A2-4E5E-BDA1-803C9BF170A1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EphemeralMongo.v2.27", "EphemeralMongo.v2.27\EphemeralMongo.v2.27.csproj", "{BBBAA089-498E-4861-B10C-93C56AFB93BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EphemeralMongo.v2.27.Tests", "EphemeralMongo.v2.27.Tests\EphemeralMongo.v2.27.Tests.csproj", "{DBB47985-C5DB-4B97-8DD9-32A0FA62D461}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +45,14 @@ Global
 		{A365BA82-91A2-4E5E-BDA1-803C9BF170A1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A365BA82-91A2-4E5E-BDA1-803C9BF170A1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A365BA82-91A2-4E5E-BDA1-803C9BF170A1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BBBAA089-498E-4861-B10C-93C56AFB93BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BBBAA089-498E-4861-B10C-93C56AFB93BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BBBAA089-498E-4861-B10C-93C56AFB93BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BBBAA089-498E-4861-B10C-93C56AFB93BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DBB47985-C5DB-4B97-8DD9-32A0FA62D461}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DBB47985-C5DB-4B97-8DD9-32A0FA62D461}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DBB47985-C5DB-4B97-8DD9-32A0FA62D461}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DBB47985-C5DB-4B97-8DD9-32A0FA62D461}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection

--- a/src/EphemeralMongo.v2.27.Tests/EphemeralMongo.v2.27.Tests.csproj
+++ b/src/EphemeralMongo.v2.27.Tests/EphemeralMongo.v2.27.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net472;net9.0</TargetFrameworks>
+    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <RootNamespace>EphemeralMongo.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+
+    <Compile Include="..\EphemeralMongo.Tests\*.cs" />
+
+    <Content Include="..\EphemeralMongo.Tests\xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EphemeralMongo.v2.27\EphemeralMongo.v2.27.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/EphemeralMongo.v2.27/EphemeralMongo.v2.27.csproj
+++ b/src/EphemeralMongo.v2.27/EphemeralMongo.v2.27.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net472;netstandard2.0;net8.0</TargetFrameworks>
+    <AssemblyName>EphemeralMongo</AssemblyName>
+    <RootNamespace>EphemeralMongo</RootNamespace>
+    <PackageId>EphemeralMongo.v2.27</PackageId>
+    <IsPackable>true</IsPackable>
+    <Description>Provides access to preconfigured MongoDB servers for testing purposes, without Docker or other dependencies.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);MONGODB_V2</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\EphemeralMongo\*.cs" />
+    <Compile Include="..\EphemeralMongo\Download\*.cs" Link="Download\%(RecursiveDir)%(Filename)%(Extension)" />
+
+    <AdditionalFiles Include="..\EphemeralMongo\*.txt" />
+
+    <InternalsVisibleTo Include="EphemeralMongo.v2.27.Tests" />
+
+    <None Include="..\..\README.md" Link="README.md" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Pack="true" PackagePath="\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MongoDB.Driver" VersionOverride="2.27.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Windows.CsWin32">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="GitVersion.MsBuild" Condition=" '$(Configuration)' == 'Release' AND !$([MSBuild]::IsOsPlatform('OSX')) ">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
+    <PackageReference Include="System.Text.Json" />
+    <Using Include="System.Net.Http" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

### ➕ Added
- `src/EphemeralMongo.v2.27/EphemeralMongo.v2.27.csproj`
  > with `<PackageReference Include="MongoDB.Driver" VersionOverride="2.27.0" />`
- `src/EphemeralMongo.v2.27.Tests/EphemeralMongo.v2.27.Tests.csproj`

## Description

We are stuck with MongoDB package version 2.27 and cannot update to 2.28 or higher due to restrictive changes made by the MongoDB team.

Therefore, we need a version that includes 2.27.

Here, I have simply added another project without affecting the existing implementation.

We would be very happy if this version could also be released.
